### PR TITLE
fix(bpmn-js): Don't clone objects when merging custom bpmn-js options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@miragon/camunda-web-modeler",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "A browser-native BPMN and DMN modeler based on bpmn.io.",
     "author": "FlowSquad GmbH <info@flowsquad.io>",
     "homepage": "https://github.com/FlowSquad/camunda-web-modeler",

--- a/src/bpmnio/bpmn/CustomBpmnJsModeler.ts
+++ b/src/bpmnio/bpmn/CustomBpmnJsModeler.ts
@@ -75,7 +75,11 @@ class CustomBpmnJsModeler extends Modeler {
                     propertiesProviderModule
                 ]
             } : {}
-        ]);
+        ], {
+            // Deprecated, but @dominikhorn93 said it's okay because it's gonna stay that way for
+            // at least 5 years (or forever)
+            clone: false
+        });
         super(mergedOptions);
     }
 

--- a/src/editor/BpmnEditor.tsx
+++ b/src/editor/BpmnEditor.tsx
@@ -178,7 +178,8 @@ const useStyles = makeStyles(() => ({
     propertiesPanel: {
         height: "100%",
         "&>div": {
-            height: "100%"
+            height: "100%",
+            overflow: "auto"
         }
     },
     hidden: {


### PR DESCRIPTION
Also add overflow: auto to properties panel container.