### PR TITLE
fix: increase version to fix failing yarn publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@miragon/camunda-web-modeler",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "A browser-native BPMN and DMN modeler based on bpmn.io.",
     "author": "FlowSquad GmbH <info@flowsquad.io>",
     "homepage": "https://github.com/FlowSquad/camunda-web-modeler",


### PR DESCRIPTION
I forgot to increase the version in the package.json. The publish command failed because of same versioning.