### PR TITLE
fix(workflows): Publish action and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/"
     target-branch: "develop"
     labels:
-      - "Technical Dept"
+      - "Technical Debt"
     schedule:
       interval: daily
       time: "05:00"
@@ -21,7 +21,7 @@ updates:
       time: "05:00"
     target-branch: "develop"
     labels:
-      - "Technical Dept"
+      - "Technical Debt"
     commit-message:
       prefix: fix
       prefix-development: chore

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,7 @@
 name: Publish
 
 on:
-  push:
-    branches: [ develop ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Changes: 
* Publish action changed to on workflow dispatch
* Dependabot spelling mistake "technical dept" to "debt" 