### PR TITLE
Replace react-resizable-panels with a custom resizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "dmn-js": "17.8.1",
     "dmn-js-properties-panel": "3.11.1",
     "monaco-editor": "0.55.1",
-    "react-resizable-panels": "3.0.6",
     "tss-react": "4.9.21"
   },
   "devDependencies": {

--- a/src/components/ResizablePanels.tsx
+++ b/src/components/ResizablePanels.tsx
@@ -1,0 +1,282 @@
+import React, {
+    PointerEvent as ReactPointerEvent,
+    KeyboardEvent as ReactKeyboardEvent,
+    MouseEvent as ReactMouseEvent,
+    ReactNode,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
+import { tss } from "tss-react";
+
+import { getEffectiveBounds, PanelSize, resolveSecondSize } from "./resizablePanelsMath";
+
+/**
+ * Props for {@link ResizablePanels}. Sizes are percentages of the container width to
+ * preserve the published `@miragon/camunda-web-modeler` contract (the old
+ * `react-resizable-panels` API was percentage-based too).
+ */
+export interface ResizablePanelsProps {
+    /** Class applied to the flex root. */
+    className?: string;
+    /**
+     * When false the root is hidden via `display: none` but stays mounted — bpmn-js /
+     * dmn-js attach to the child container DOM nodes, so unmounting would tear them down.
+     */
+    active: boolean;
+    /** Left panel (modeler); flexes to fill whatever the second panel leaves. */
+    firstPanel: ReactNode;
+    /** Right panel (properties); explicit width, resizable and collapsible. */
+    secondPanel: ReactNode;
+    /** First-panel size constraints in %. Defaults 75 / 5 / 95. */
+    firstPanelSize?: PanelSize;
+    /** Second-panel size constraints in %. Defaults 25 / 5 / 95. */
+    secondPanelSize?: PanelSize;
+    /** Fired on mount with the initial sizes and on every subsequent change. */
+    onResize?: (firstSize: number, secondSize: number) => void;
+}
+
+const DIVIDER_WIDTH = 5;
+/** Step (in %) applied per ArrowLeft/ArrowRight press on the focused divider. */
+const KEYBOARD_STEP = 1;
+
+const useStyles = tss.create(() => ({
+    root: {
+        display: "flex",
+        flexDirection: "row",
+        width: "100%",
+        height: "100%",
+    },
+    hidden: {
+        display: "none",
+    },
+    firstPanel: {
+        flex: "1 1 0",
+        minWidth: 0,
+        overflow: "hidden",
+    },
+    divider: {
+        flex: "none",
+        position: "relative",
+        width: `${DIVIDER_WIDTH}px`,
+        cursor: "col-resize",
+        backgroundColor: "rgba(0, 0, 0, 0.25)",
+        touchAction: "none",
+    },
+    secondPanel: {
+        flex: "none",
+        overflow: "hidden",
+    },
+    toggleButton: {
+        position: "absolute",
+        top: "50%",
+        right: "100%",
+        transform: "translateY(-50%)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: "20px",
+        height: "40px",
+        padding: 0,
+        border: "none",
+        cursor: "pointer",
+        color: "rgba(0, 0, 0, 0.54)",
+        fill: "rgba(0, 0, 0, 0.54)",
+        backgroundColor: "rgba(0, 0, 0, 0.1)",
+        borderTopLeftRadius: "4px",
+        borderBottomLeftRadius: "4px",
+        "&:hover": {
+            color: "rgba(0, 0, 0, 0.87)",
+            fill: "rgba(0, 0, 0, 0.87)",
+            backgroundColor: "rgba(0, 0, 0, 0.2)",
+        },
+    },
+}));
+
+/**
+ * A purpose-built, controlled horizontal split with a draggable divider and a
+ * collapse-to-zero toggle for the second panel. Replaces `react-resizable-panels`,
+ * whose React peer range conflicted with this repo's intentional React 17 support.
+ *
+ * Only the second (properties) panel's size is tracked as state; the first (modeler)
+ * panel flexes to the remainder. Keeping a single source of truth makes the math 1:1
+ * with the emitted `onResize` second value.
+ */
+const ResizablePanels: React.FC<ResizablePanelsProps> = props => {
+    const {
+        className,
+        active,
+        firstPanel,
+        secondPanel,
+        firstPanelSize,
+        secondPanelSize,
+        onResize,
+    } = props;
+
+    const { classes, cx } = useStyles();
+
+    const bounds = useMemo(
+        () => getEffectiveBounds(firstPanelSize ?? {}, secondPanelSize ?? {}),
+        [firstPanelSize, secondPanelSize],
+    );
+
+    const initialSize = secondPanelSize?.initial ?? 25;
+
+    // `sizePct` is the panel's size while expanded; `collapsed` overrides it to 0 for
+    // both layout and the emitted event, while preserving a size to restore on reopen.
+    const [sizePct, setSizePct] = useState(initialSize);
+    const [collapsed, setCollapsed] = useState(false);
+
+    const rootRef = useRef<HTMLDivElement | null>(null);
+
+    // Hold the latest onResize so the emit effect can depend only on the sizes, firing
+    // once on mount and once per change without re-firing when the callback identity
+    // (which the editors recreate from props) changes.
+    const onResizeRef = useRef(onResize);
+    useEffect(() => {
+        onResizeRef.current = onResize;
+    });
+
+    const secondSize = collapsed ? 0 : sizePct;
+
+    useEffect(() => {
+        onResizeRef.current?.(100 - secondSize, secondSize);
+    }, [secondSize]);
+
+    /**
+     * Applies a raw second-panel percentage through the shared math, updating both the
+     * collapsed flag and the remembered size.
+     */
+    const applyRawSize = useCallback(
+        (rawPct: number) => {
+            const resolved = resolveSecondSize(rawPct, bounds);
+            setCollapsed(resolved.collapsed);
+            if (!resolved.collapsed) {
+                setSizePct(resolved.sizePct);
+            }
+        },
+        [bounds],
+    );
+
+    /**
+     * Translates a pointer x-coordinate into the second panel's percentage. The second
+     * panel hugs the right edge, so its width is the distance from the cursor to the
+     * container's right edge.
+     */
+    const sizeFromPointer = useCallback((clientX: number): number | undefined => {
+        const root = rootRef.current;
+        if (!root) {
+            return undefined;
+        }
+        const rect = root.getBoundingClientRect();
+        if (rect.width === 0) {
+            return undefined;
+        }
+        return ((rect.right - clientX) / rect.width) * 100;
+    }, []);
+
+    const handlePointerMove = useCallback(
+        (event: ReactPointerEvent<HTMLDivElement>) => {
+            const rawPct = sizeFromPointer(event.clientX);
+            if (rawPct !== undefined) {
+                applyRawSize(rawPct);
+            }
+        },
+        [applyRawSize, sizeFromPointer],
+    );
+
+    const handlePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        event.currentTarget.setPointerCapture(event.pointerId);
+        // Suppress text selection / cursor flicker across the whole document while
+        // dragging, mirroring react-resizable-panels' drag affordance.
+        document.body.style.cursor = "col-resize";
+        document.body.style.userSelect = "none";
+    }, []);
+
+    const endDrag = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+            event.currentTarget.releasePointerCapture(event.pointerId);
+        }
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+    }, []);
+
+    const handleKeyDown = useCallback(
+        (event: ReactKeyboardEvent<HTMLDivElement>) => {
+            // ArrowLeft grows the right-hand panel (divider moves left); ArrowRight shrinks it.
+            if (event.key === "ArrowLeft") {
+                event.preventDefault();
+                applyRawSize(secondSize + KEYBOARD_STEP);
+            } else if (event.key === "ArrowRight") {
+                event.preventDefault();
+                applyRawSize(secondSize - KEYBOARD_STEP);
+            }
+        },
+        [applyRawSize, secondSize],
+    );
+
+    const openPanel = useCallback(() => {
+        setCollapsed(false);
+        setSizePct(initialSize);
+    }, [initialSize]);
+
+    return (
+        <div
+            ref={rootRef}
+            className={cx(classes.root, !active && classes.hidden, className)}
+        >
+            <div className={classes.firstPanel}>{firstPanel}</div>
+
+            <div
+                className={classes.divider}
+                role="separator"
+                aria-orientation="vertical"
+                tabIndex={0}
+                onPointerDown={handlePointerDown}
+                onPointerMove={handlePointerMove}
+                onPointerUp={endDrag}
+                onPointerCancel={endDrag}
+                onKeyDown={handleKeyDown}
+            >
+                {collapsed && (
+                    <button
+                        type="button"
+                        className={classes.toggleButton}
+                        aria-label="Open properties panel"
+                        title="Open properties panel"
+                        // Prevent the click from initiating a divider drag.
+                        onPointerDown={(e: ReactPointerEvent) => {
+                            e.stopPropagation();
+                        }}
+                        onMouseDown={(e: ReactMouseEvent) => {
+                            e.stopPropagation();
+                        }}
+                        onClick={openPanel}
+                    >
+                        <svg width="12" height="12" viewBox="0 0 24 24">
+                            <path
+                                d="M15 6l-6 6 6 6"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                            />
+                        </svg>
+                    </button>
+                )}
+            </div>
+
+            <div
+                className={classes.secondPanel}
+                style={{ width: `${secondSize}%` }}
+                aria-hidden={collapsed}
+            >
+                {secondPanel}
+            </div>
+        </div>
+    );
+};
+
+export default ResizablePanels;

--- a/src/components/resizablePanelsMath.test.ts
+++ b/src/components/resizablePanelsMath.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { getEffectiveBounds, resolveSecondSize } from "./resizablePanelsMath";
+
+/**
+ * Unit tests for the pure resizer math. They cover the decisions that are easy to get
+ * wrong and impossible to exercise via typecheck: the intersected bounds, the clamp,
+ * and the collapse/expand threshold around the effective minimum.
+ */
+describe("getEffectiveBounds", () => {
+    it("applies the documented defaults (75/5/95 and 25/5/95)", () => {
+        // second min/max are 5/95, first min/max imply 5/95 → intersection is 5/95.
+        expect(getEffectiveBounds({}, {})).toEqual({ min: 5, max: 95 });
+    });
+
+    it("floors the second panel by the first panel's maximum", () => {
+        // first max 80 ⇒ second can never drop below 20.
+        const bounds = getEffectiveBounds({ max: 80 }, { min: 5 });
+        expect(bounds.min).toBe(20);
+    });
+
+    it("caps the second panel by the first panel's minimum", () => {
+        // first min 30 ⇒ second can never exceed 70.
+        const bounds = getEffectiveBounds({ min: 30 }, { max: 95 });
+        expect(bounds.max).toBe(70);
+    });
+
+    it("keeps the tighter of the two constraints on each side", () => {
+        const bounds = getEffectiveBounds({ min: 10, max: 90 }, { min: 15, max: 85 });
+        // second min 15 > (100-90)=10 ⇒ 15; second max 85 < (100-10)=90 ⇒ 85.
+        expect(bounds).toEqual({ min: 15, max: 85 });
+    });
+});
+
+describe("resolveSecondSize", () => {
+    const bounds = { min: 5, max: 95 };
+
+    it("passes through a value within bounds", () => {
+        expect(resolveSecondSize(40, bounds)).toEqual({ sizePct: 40, collapsed: false });
+    });
+
+    it("clamps a value above the maximum", () => {
+        expect(resolveSecondSize(120, bounds)).toEqual({
+            sizePct: 95,
+            collapsed: false,
+        });
+    });
+
+    it("collapses when dragged below the minimum", () => {
+        expect(resolveSecondSize(2, bounds)).toEqual({ sizePct: 0, collapsed: true });
+    });
+
+    it("expands from collapsed once back at or above the minimum", () => {
+        // The exact minimum is the first non-collapsed size.
+        expect(resolveSecondSize(5, bounds)).toEqual({ sizePct: 5, collapsed: false });
+    });
+});

--- a/src/components/resizablePanelsMath.ts
+++ b/src/components/resizablePanelsMath.ts
@@ -1,0 +1,67 @@
+/**
+ * Pure layout math for {@link ResizablePanels}. Extracted from the component so the
+ * non-trivial clamp/collapse decisions can be unit-tested without a DOM (SRP). The
+ * component owns the React state and pointer wiring; this module owns the numbers.
+ */
+
+/**
+ * The resolved size constraints of a single panel, in percentages of the container.
+ */
+export interface PanelSize {
+    /** Initial size in % (defaults applied by the caller). */
+    initial?: number;
+    /** Minimum size in %. */
+    min?: number;
+    /** Maximum size in %. */
+    max?: number;
+}
+
+/** The effective lower/upper bounds (in %) the second panel may occupy. */
+export interface Bounds {
+    min: number;
+    max: number;
+}
+
+/** The outcome of resolving a raw drag position into a concrete panel size. */
+export interface ResolvedSize {
+    /** The clamped size in %. Zero when collapsed. */
+    sizePct: number;
+    /** Whether the second panel collapsed (dropped below its effective minimum). */
+    collapsed: boolean;
+}
+
+/**
+ * Computes the range the second (properties) panel may occupy. Because the first
+ * panel flexes to `100 - secondPct`, the second panel's own min/max alone are not
+ * enough: we must intersect them with the bounds implied by the first panel so that
+ * BOTH panels stay inside their configured limits. A first-panel min of 5 caps the
+ * second at 95; a first-panel max of 95 floors the second at 5, and so on.
+ */
+export const getEffectiveBounds = (first: PanelSize, second: PanelSize): Bounds => {
+    const firstMin = first.min ?? 5;
+    const firstMax = first.max ?? 95;
+    const secondMin = second.min ?? 5;
+    const secondMax = second.max ?? 95;
+
+    return {
+        min: Math.max(secondMin, 100 - firstMax),
+        max: Math.min(secondMax, 100 - firstMin),
+    };
+};
+
+/**
+ * Maps a raw drag percentage to a concrete second-panel size. Dragging below the
+ * effective minimum snaps the panel shut (collapsed) rather than leaving a sliver,
+ * which is what enables the toggle-to-reopen UX; otherwise the value is clamped into
+ * the allowed range. Dragging a collapsed panel back past the minimum re-expands it,
+ * since any `rawPct >= min` resolves to a non-collapsed, clamped size.
+ */
+export const resolveSecondSize = (rawPct: number, bounds: Bounds): ResolvedSize => {
+    if (rawPct < bounds.min) {
+        return { sizePct: 0, collapsed: true };
+    }
+    return {
+        sizePct: Math.min(bounds.max, rawPct),
+        collapsed: false,
+    };
+};

--- a/src/editor/BpmnEditor.tsx
+++ b/src/editor/BpmnEditor.tsx
@@ -6,9 +6,9 @@ import React, {
     useRef,
     useState,
 } from "react";
-import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { tss } from "tss-react";
 
+import ResizablePanels from "../components/ResizablePanels";
 import CustomBpmnJsModeler from "../bpmnio/bpmn/CustomBpmnJsModeler";
 import { createBpmnIoEvent } from "../events/bpmnio/BpmnIoEvents";
 import { Event } from "../events";
@@ -383,8 +383,8 @@ const BpmnEditor: React.FC<BpmnEditorProps> = props => {
     }, [propertiesPanelOptions?.hidden, propertiesPanelOptions?.elementTemplates]);
 
     const onPropertiesPanelWidthChanged = useCallback(
-        (sizes: number[]) => {
-            onEvent(createPropertiesPanelResizedEvent(sizes[1]));
+        (_first: number, second: number) => {
+            onEvent(createPropertiesPanelResizedEvent(second));
         },
         [onEvent],
     );
@@ -407,36 +407,15 @@ const BpmnEditor: React.FC<BpmnEditorProps> = props => {
     }
 
     return (
-        <PanelGroup
+        <ResizablePanels
             className={className}
-            direction="horizontal"
-            onLayout={onPropertiesPanelWidthChanged}
-            style={{
-                display: props.active ? "flex" : "none",
-            }}
-        >
-            <Panel
-                defaultSize={modelerOptions?.size?.initial ?? 75}
-                maxSize={modelerOptions?.size?.max ?? 95}
-                minSize={modelerOptions?.size?.min ?? 5}
-            >
-                {modelerContainer}
-            </Panel>
-            <PanelResizeHandle
-                style={{
-                    cursor: "col-resize",
-                    width: "5px",
-                    backgroundColor: "rgba(0, 0, 0, 0.25)",
-                }}
-            />
-            <Panel
-                defaultSize={propertiesPanelOptions?.size?.initial ?? 25}
-                maxSize={propertiesPanelOptions?.size?.max ?? 95}
-                minSize={propertiesPanelOptions?.size?.min ?? 5}
-            >
-                {propertiesPanelContainer}
-            </Panel>
-        </PanelGroup>
+            active={props.active}
+            firstPanel={modelerContainer}
+            secondPanel={propertiesPanelContainer}
+            firstPanelSize={modelerOptions?.size}
+            secondPanelSize={propertiesPanelOptions?.size}
+            onResize={onPropertiesPanelWidthChanged}
+        />
     );
 };
 

--- a/src/editor/DmnEditor.tsx
+++ b/src/editor/DmnEditor.tsx
@@ -6,8 +6,7 @@ import React, {
     useRef,
     useState,
 } from "react";
-import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
-
+import ResizablePanels from "../components/ResizablePanels";
 import CustomDmnJsModeler, { DmnView } from "../bpmnio/dmn/CustomDmnJsModeler";
 import { createBpmnIoEvent } from "../events/bpmnio/BpmnIoEvents";
 import { Event } from "../events";
@@ -359,8 +358,8 @@ const DmnEditor: React.FC<DmnEditorProps> = props => {
     }, [xml, importXml, initializeCount]);
 
     const onPropertiesPanelWidthChanged = useCallback(
-        (sizes: number[]) => {
-            onEvent(createPropertiesPanelResizedEvent(sizes[1]));
+        (_first: number, second: number) => {
+            onEvent(createPropertiesPanelResizedEvent(second));
         },
         [onEvent],
     );
@@ -383,36 +382,15 @@ const DmnEditor: React.FC<DmnEditorProps> = props => {
     }
 
     return (
-        <PanelGroup
+        <ResizablePanels
             className={className}
-            direction="horizontal"
-            onLayout={onPropertiesPanelWidthChanged}
-            style={{
-                display: props.active ? "flex" : "none",
-            }}
-        >
-            <Panel
-                defaultSize={modelerOptions?.size?.initial ?? 75}
-                maxSize={modelerOptions?.size?.max ?? 95}
-                minSize={modelerOptions?.size?.min ?? 5}
-            >
-                {modelerContainer}
-            </Panel>
-            <PanelResizeHandle
-                style={{
-                    cursor: "col-resize",
-                    width: "5px",
-                    backgroundColor: "rgba(0, 0, 0, 0.25)",
-                }}
-            />
-            <Panel
-                defaultSize={propertiesPanelOptions?.size?.initial ?? 25}
-                maxSize={propertiesPanelOptions?.size?.max ?? 95}
-                minSize={propertiesPanelOptions?.size?.min ?? 5}
-            >
-                {propertiesPanelContainer}
-            </Panel>
-        </PanelGroup>
+            active={props.active}
+            firstPanel={modelerContainer}
+            secondPanel={propertiesPanelContainer}
+            firstPanelSize={modelerOptions?.size}
+            secondPanelSize={propertiesPanelOptions?.size}
+            onResize={onPropertiesPanelWidthChanged}
+        />
     );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,7 +1251,6 @@ __metadata:
     jsdom: "npm:29.1.1"
     monaco-editor: "npm:0.55.1"
     prettier: "npm:3.8.3"
-    react-resizable-panels: "npm:3.0.6"
     rimraf: "npm:6.1.3"
     rollup: "npm:4.60.4"
     rollup-plugin-css-only: "npm:4.5.5"
@@ -6258,16 +6257,6 @@ __metadata:
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 10c0/33977da7a5f1a287936a0c85639fec6ca74f4f15ef1e59a6bc20338fc73dc69555381e211f7a3529b8150a1f71e4225525b41b60b52965bda53ce7d47377ada1
-  languageName: node
-  linkType: hard
-
-"react-resizable-panels@npm:3.0.6":
-  version: 3.0.6
-  resolution: "react-resizable-panels@npm:3.0.6"
-  peerDependencies:
-    react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-  checksum: 10c0/e6a6a2a7f438aaf3d4411c39626c1cab5c23af6f25d5ff1fdb8446916388fec549be63d65c47fe17bcc82522b1b5fc7fffa77a550ca9d0b8d21e340d83bdb3c0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Drops the `react-resizable-panels` runtime dependency, whose React peer range conflicted with this repo's intentional `react ^17 || ^18` support, and replaces it with a small, purpose-built `ResizablePanels` component (draggable divider with pointer-capture, keyboard a11y, and a collapse-to-zero toggle button to reopen the properties panel). The existing percentage-based public contract (modeler 75/5/95, properties 25/5/95) and the `properties.panel.resized` event are preserved, so consuming configurations keep working. Layout math is extracted into a pure `resizablePanelsMath.ts` helper covered by unit tests, and `BpmnEditor`/`DmnEditor` are rewired to the new component. Verified with `yarn build`, `yarn lint`, `yarn format:check`, and `yarn test` (12 passing). Note: the full drag/collapse interaction can't be exercised headlessly in this repo (no example harness), so it should be confirmed in a consuming app.